### PR TITLE
Allow for users of the role to define their own slurm.conf.j2 templat…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # defaults file for ansible-role-slurm
 
+# define the template name to allow further customization
+slurm_conf_template: "etc/slurm/slurm.conf.j2"
 # add the public OpenHPC yum repos
 slurm_add_ohpc_repos: true
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -100,8 +100,8 @@
 
 - name: deploy /etc/slurm/slurm.conf
   template:
+    src: "{{ slurm_conf_template }}"
     dest: /etc/slurm/slurm.conf
-    src: etc/slurm/slurm.conf.j2
     owner: root
     group: root
     mode: 0644


### PR DESCRIPTION
For the internal jupyterhub-edu nodes I was using this variation of the role that allows you to define a custom `slurm.conf.j2` template, I forgot to upload the changes some time ago, this is so is not forgotten again by me.